### PR TITLE
Allow IRI nodes to have all operation available

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ./db:/iri/data
     command: >-
       --testnet 
+      --remote-limit-api ""
       --remote 
       --testnet-coordinator ZRMNUUBQHVRFRFBOQZYGAUBSTJSHDVIPXHUDA9VAXFTDSGGRILPVMYLVOLVCIEHLFMQKUOHUIUWILCXGD
       --testnet-coordinator-security-level 1


### PR DESCRIPTION
Allow IRI nodes to have all operation available, things like remote Pow, add neighbours etc.