### PR TITLE
Update Docker image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       -statePath /state/statefile
   iri:
     network_mode: host
-    image: "iotaledger/iri:latest"
+    image: "iotaledger/iri:v1.8.2-RELEASE"
     ports:
       - "${IRI_PORT}:${IRI_PORT}"
       - "5556:5556"


### PR DESCRIPTION
The `iotaledger/iri` image doesn't have a `latest` version tag, updated to use latest release `v1.8.2-RELEASE` :) Using this repo in the Diffusion hackathon tomorrow!