### PR TITLE
Add missing port config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ./config/snapshot.txt:/snapshot.txt
       - ./db:/iri/data
     command: >-
+      --port ${IRI_PORT}
       --testnet true
       --remote true
       --zmq-enable-tcp true


### PR DESCRIPTION
Need to configure IRI to use variable form `.env`